### PR TITLE
Support use `distroless` as the base image

### DIFF
--- a/1/debian9/1.3/Dockerfile
+++ b/1/debian9/1.3/Dockerfile
@@ -35,6 +35,7 @@ COPY --from=downloader /release/LICENSE /kube-state-metrics-LICENSE
 COPY --from=builder /go/src/k8s.io/kube-state-metrics/kube-state-metrics /
 
 VOLUME /tmp
+USER nobody
 
 EXPOSE 8080
 EXPOSE 8081

--- a/1/debian9/1.4/Dockerfile
+++ b/1/debian9/1.4/Dockerfile
@@ -35,6 +35,7 @@ COPY --from=downloader /release/LICENSE /kube-state-metrics-LICENSE
 COPY --from=builder /go/src/k8s.io/kube-state-metrics/kube-state-metrics /
 
 VOLUME /tmp
+USER nobody
 
 EXPOSE 8080
 EXPOSE 8081

--- a/1/debian9/1.5/Dockerfile
+++ b/1/debian9/1.5/Dockerfile
@@ -35,6 +35,7 @@ COPY --from=downloader /release/LICENSE /kube-state-metrics-LICENSE
 COPY --from=builder /go/src/k8s.io/kube-state-metrics/kube-state-metrics /
 
 VOLUME /tmp
+USER nobody
 
 EXPOSE 8080
 EXPOSE 8081

--- a/1/debian9/1.6/Dockerfile
+++ b/1/debian9/1.6/Dockerfile
@@ -35,6 +35,7 @@ COPY --from=downloader /release/LICENSE /kube-state-metrics-LICENSE
 COPY --from=builder /go/src/k8s.io/kube-state-metrics/kube-state-metrics /
 
 VOLUME /tmp
+USER nobody
 
 EXPOSE 8080
 EXPOSE 8081

--- a/1/debian9/1.9/Dockerfile
+++ b/1/debian9/1.9/Dockerfile
@@ -35,6 +35,7 @@ COPY --from=downloader /release/LICENSE /kube-state-metrics-LICENSE
 COPY --from=builder /go/src/k8s.io/kube-state-metrics/kube-state-metrics /
 
 VOLUME /tmp
+USER nobody
 
 EXPOSE 8080
 EXPOSE 8081

--- a/1/distroless/1.9/Dockerfile
+++ b/1/distroless/1.9/Dockerfile
@@ -35,7 +35,7 @@ COPY --from=downloader /release/LICENSE /kube-state-metrics-LICENSE
 COPY --from=builder /go/src/k8s.io/kube-state-metrics/kube-state-metrics /
 
 VOLUME /tmp
-User nobody
+USER nobody
 
 EXPOSE 8080
 EXPOSE 8081

--- a/1/distroless/1.9/Dockerfile
+++ b/1/distroless/1.9/Dockerfile
@@ -1,0 +1,43 @@
+# Download and unpack the Kube State Merics release code from github
+FROM gcr.io/google-appengine/debian9 as downloader
+
+ENV KUBE_STATE_METRICS_VERSION 1.9.7
+
+RUN set -x && \
+    apt-get update && \
+    apt-get install -qq -y wget git && \
+    git clone https://github.com/kubernetes/kube-state-metrics.git --branch v${KUBE_STATE_METRICS_VERSION} release
+
+# Build the binary with Go
+FROM golang:1.15 as builder
+WORKDIR /go/src/k8s.io/kube-state-metrics
+
+ENV PKG=k8s.io/kube-state-metrics
+ENV TAG=1.9.7
+
+ENV GCO_ENABLED=0
+ENV GOOS=linux
+
+COPY --from=downloader release /go/src/k8s.io/kube-state-metrics
+
+RUN set -x && \
+    BuildDate="$(date -u +%Y-%m-%dT%H:%M:%SZ)" && \
+    go build \
+      -ldflags="-s -w -X ${PKG}/version.Release=${TAG} -X ${PKG}/version.BuildDate=${BuildDate}" \
+      -o kube-state-metrics
+
+# Build the final image
+FROM gcr.io/distroless/static:latest
+
+ENV C2D_RELEASE=1.9.7
+
+COPY --from=downloader /release/LICENSE /kube-state-metrics-LICENSE
+COPY --from=builder /go/src/k8s.io/kube-state-metrics/kube-state-metrics /
+
+VOLUME /tmp
+User nobody
+
+EXPOSE 8080
+EXPOSE 8081
+
+ENTRYPOINT ["/kube-state-metrics", "--port=8080", "--telemetry-port=8081"]

--- a/templates/Dockerfile.template
+++ b/templates/Dockerfile.template
@@ -38,6 +38,7 @@ COPY --from=downloader /release/LICENSE /kube-state-metrics-LICENSE
 COPY --from=builder /go/src/k8s.io/kube-state-metrics/kube-state-metrics /
 
 VOLUME /tmp
+USER nobody
 
 EXPOSE 8080
 EXPOSE 8081

--- a/versions.yaml
+++ b/versions.yaml
@@ -17,7 +17,7 @@ cloudbuild:
   enable_parallel: false
 versions:
 - dir: 1/distroless/1.9
-  from: marketplace.gcr.io/google/debian9
+  from: gcr.io/distroless/static:latest
   packages:
     kubestatemetrics:
       version: 1.9.7

--- a/versions.yaml
+++ b/versions.yaml
@@ -16,6 +16,18 @@
 cloudbuild:
   enable_parallel: false
 versions:
+- dir: 1/distroless/1.9
+  from: marketplace.gcr.io/google/debian9
+  packages:
+    kubestatemetrics:
+      version: 1.9.7
+  repo: kube-state-metrics1
+  tags:
+  - 1.9.7-distroless
+  - 1.9-distroless
+  - 1-distroless
+  templateArgs:
+    golangVersion: '1.15'
 - dir: 1/debian9/1.9
   from: marketplace.gcr.io/google/debian9
   packages:
@@ -84,4 +96,3 @@ versions:
   - '1.3'
   templateArgs:
     golangVersion: 1.10.1
-


### PR DESCRIPTION
- The upstream of kube-state-metrics already switched to use distroless
for its minimal attack surface for container:
https://github.com/kubernetes/kube-state-metrics/blob/master/Dockerfile

Signed-off-by: Yu Yi <yiyu@google.com>

Fixes: https://github.com/GoogleCloudPlatform/kube-state-metrics-docker/issues/23