### PR TITLE
Distroless base image update for 1.9

### DIFF
--- a/1/distroless/1.9/Dockerfile
+++ b/1/distroless/1.9/Dockerfile
@@ -27,7 +27,7 @@ RUN set -x && \
       -o kube-state-metrics
 
 # Build the final image
-FROM gcr.io/distroless/static:latest
+FROM gcr.io/distroless/base:latest
 
 ENV C2D_RELEASE=1.9.7
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -17,7 +17,7 @@ cloudbuild:
   enable_parallel: false
 versions:
 - dir: 1/distroless/1.9
-  from: gcr.io/distroless/static:latest
+  from: gcr.io/distroless/base:latest
   packages:
     kube-state-metrics:
       version: 1.9.7


### PR DESCRIPTION
Use distroless/base instead of distroless/static which does not work for 1.9.7