### PR TITLE
Remove distroless from versions.yaml

### DIFF
--- a/1/distroless/README.md
+++ b/1/distroless/README.md
@@ -1,0 +1,1 @@
+This directory contains frozen `distroless` version which is not part of `versions.yaml`

--- a/versions.yaml
+++ b/versions.yaml
@@ -16,18 +16,6 @@
 cloudbuild:
   enable_parallel: false
 versions:
-- dir: 1/distroless/1.9
-  from: gcr.io/distroless/base:latest
-  packages:
-    kube-state-metrics:
-      version: 1.9.7
-  repo: kube-state-metrics1
-  tags:
-  - 1.9.7-distroless
-  - 1.9-distroless
-  - 1-distroless
-  templateArgs:
-    golangVersion: '1.15'
 - dir: 2/debian9/2.2
   from: marketplace.gcr.io/google/debian9
   packages:


### PR DESCRIPTION
Remove distroless from `versions.yaml` as it is not released under click-to-deploy partner project.
`Dockefile` for frozen distroless version still available in this directory `kube-state-metrics-docker/1/distroless/1.9/`